### PR TITLE
zconfservicebrowser.h: use stdint.h instead stdint-gcc.h

### DIFF
--- a/zconfservicebrowser.h
+++ b/zconfservicebrowser.h
@@ -21,7 +21,7 @@
 #define ZCONFSERVICEBROWSER_H
 
 #include <QObject>
-#include <stdint-gcc.h>
+#include <stdint.h>
 #include <avahi-client/lookup.h>
 
 struct ZConfServiceEntry


### PR DESCRIPTION
Use stdint.h instead of GCC ONLY stdint-gcc.h, this make us can build
with clang or other compilers.

Signed-off-by: Yen-Chin Lee coldnew.tw@gmail.com
